### PR TITLE
configury: simplify C and C++ test link

### DIFF
--- a/config/mpirshim_lang_link_with_c.m4
+++ b/config/mpirshim_lang_link_with_c.m4
@@ -13,51 +13,42 @@ dnl
 dnl $HEADER$
 dnl
 
-# MPIRSHIM_LANG_LINK_WITH_C(language)
+# MPIRSHIM_TEST_LINK_C_AND_CXX([action if happy], [action if unhappy])
 # -------------------------------
 # Try to link a small test program against a C object file to make
 # sure the compiler for the given language is compatible with the C
 # compiler.
-AC_DEFUN([MPIRSHIM_LANG_LINK_WITH_C], [
-  AS_VAR_PUSHDEF([lang_var], [mpirshim_cv_c_link_$1])
+AC_DEFUN([MPIRSHIM_TEST_LINK_C_AND_CXX], [
+    MPIRSHIM_VAR_SCOPE_PUSH([result])
+    AC_MSG_CHECKING([if C and C++ are link compatible])
 
-  AC_CACHE_CHECK([if C and $1 are link compatible],
-    lang_var,
-    [
-     # Write out C part
-     AC_LANG_PUSH(C)
-     rm -f conftest_c.$ac_ext
-      cat > conftest_c.$ac_ext << EOF
+    # Write out and compile C part
+    AC_LANG_PUSH([C])
+    rm -f conftest_c.$ac_ext
+    cat > conftest_c.$ac_ext << EOF
 int testfunc(int a);
 int testfunc(int a) { return a; }
 EOF
+    MPIRSHIM_LOG_COMMAND([$CC -c $CFLAGS $CPPFLAGS conftest_c.$ac_ext])
 
-     # Now compile both parts
-     MPIRSHIM_LOG_COMMAND([$CC -c $CFLAGS $CPPFLAGS conftest_c.$ac_ext],
-       [AC_LANG_PUSH($1)
-        mpirshim_lang_link_with_c_libs="$LIBS"
-        LIBS="conftest_c.o $LIBS"
-        m4_if(mpirshim_lang_link_with_c_fortran, 1,
-          [AC_LINK_IFELSE([AC_LANG_PROGRAM([], [
-       external testfunc
-       call testfunc(1)
-])],
-             [AS_VAR_SET(lang_var, ["yes"])], [AS_VAR_SET(lang_var, ["no"])])],
-          [AC_LINK_IFELSE([AC_LANG_PROGRAM([
-#if defined(c_plusplus) || defined(__cplusplus)
+    # Now try linking together with C++
+    AC_LANG_PUSH([C++])
+    mpirshim_lang_link_with_c_libs=$LIBS
+    LIBS="conftest_c.o $LIBS"
+    AC_LINK_IFELSE([AC_LANG_PROGRAM([
 extern "C" int testfunc(int);
-#else
-extern int testfunc(int);
-#endif
 ],
-             [return testfunc(0);])],
-             [AS_VAR_SET(lang_var, ["yes"])], [AS_VAR_SET(lang_var, ["no"])])])
-        LIBS="$mpirshim_lang_link_with_c_libs"
-        AC_LANG_POP($1)],
-       [AS_VAR_SET(lang_var, ["no"])])
-     rm -f conftest_c.$ac_ext
-     AC_LANG_POP(C)])
+        [return testfunc(0);])],
+        [result=yes],
+        [result=no])
 
-  AS_VAR_IF(lang_var, [yes], [$2], [$3])
-  AS_VAR_POPDEF([lang_var])dnl
+    LIBS=$mpirshim_lang_link_with_c_libs
+    AC_LANG_POP([C++])
+    rm -f conftest_c.$ac_ext
+    AC_LANG_POP([C])
+
+    AC_MSG_RESULT([$result])
+    AS_IF([test "$result" = "yes"], [$1], [$2])
+
+    MPIRSHIM_VAR_SCOPE_POP
 ])

--- a/config/mpirshim_setup_cxx.m4
+++ b/config/mpirshim_setup_cxx.m4
@@ -221,7 +221,7 @@ AC_DEFUN([_MPIRSHIM_SETUP_CXX_COMPILER_BACKEND],[
 
     # Make sure we can link with the C compiler
     if test "$mpirshim_cv_cxx_compiler_vendor" != "microsoft"; then
-      MPIRSHIM_LANG_LINK_WITH_C([C++], [],
+      MPIRSHIM_TEST_LINK_C_AND_CXX([],
         [cat <<EOF >&2
 **********************************************************************
 * It appears that your C++ compiler is unable to link against object


### PR DESCRIPTION
Remove all Fortran and make the test much simpler.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>